### PR TITLE
Release 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [4.0.3] - 2024-03-18
+
+### Updated
+- block registration doesn't rely on `react-html-parser` package anymore
+- updated dependencies
+
 ## [4.0.2] - 2024-03-13
 
 ### Updated
@@ -20,5 +26,6 @@ Initial release.
 
 [Unreleased]: https://github.com/infinum/eightshift-frontend-libs-compat/compare/master...HEAD
 
+[4.0.3]: https://github.com/infinum/eightshift-frontend-libs-compat/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/infinum/eightshift-frontend-libs-compat/compare/4.0.1...4.0.2
 [4.0.1]: https://github.com/infinum/eightshift-frontend-libs-compat/compare/4.0.0...4.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@eightshift/frontend-libs-compat",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "A small set of functions to preserve compatibility in projects using older Frontend Libs versions, while allowing new versions of Frontend Libs to be used alongside.",
 	"author": {
 		"name": "Eightshift team",
@@ -29,16 +29,15 @@
 	"homepage": "https://github.com/infinum/eightshift-frontend-libs-compat#readme",
 	"license": "MIT",
 	"dependencies": {
-		"@wordpress/block-editor": "12.18.2",
-		"@wordpress/blocks": "^12.27.1",
-		"@wordpress/element": "^5.27.0",
+		"@wordpress/block-editor": "12.21.0",
+		"@wordpress/blocks": "^12.30.0",
+		"@wordpress/element": "^5.30.0",
 		"just-camel-case": "^6.2.0",
 		"just-debounce-it": "^3.2.0",
 		"just-has": "^2.3.0",
 		"just-is-empty": "^3.4.1",
 		"just-kebab-case": "^4.2.0",
-		"just-throttle": "^4.2.0",
-		"react-html-parser": "^2.0.2"
+		"just-throttle": "^4.2.0"
 	},
 	"sideEffects": false
 }

--- a/scripts/editor/register-blocks.js
+++ b/scripts/editor/register-blocks.js
@@ -3,7 +3,6 @@ import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { createElement } from '@wordpress/element';
 import { blockIcons } from '../helpers/block-icons';
-import reactHtmlParser from 'react-html-parser';
 
 /**
  * Filter array of JS paths and get the correct edit components.
@@ -222,14 +221,14 @@ export const getIconOptions = (globalManifest, blockManifest) => {
 		return {
 			background: (typeof icon.background === 'undefined') ? backgroundGlobal : icon.background,
 			foreground: (typeof icon.foreground === 'undefined') ? foregroundGlobal : icon.foreground,
-			src: reactHtmlParser(blockIcons[icon.src])[0],
+			src: <span dangerouslySetInnerHTML={{ __html: blockIcons[icon.src] }} />,
 		};
 	}
 
 	return {
 		background: (typeof icon.background === 'undefined') ? backgroundGlobal : icon.background,
 		foreground: (typeof icon.foreground === 'undefined') ? foregroundGlobal : icon.foreground,
-		src: (icon.src.includes('<svg')) ? reactHtmlParser(icon.src)[0] : icon.src,
+		src: icon.src.includes('<svg') ? <span dangerouslySetInnerHTML={{ __html: icon.src }} /> : icon.src,
 	};
 };
 


### PR DESCRIPTION
### Updated
- block registration doesn't rely on `react-html-parser` package anymore
- updated dependencies